### PR TITLE
Feature/codebook

### DIFF
--- a/scoda/static/src/sass/components/_codebook.scss
+++ b/scoda/static/src/sass/components/_codebook.scss
@@ -262,10 +262,21 @@
   text-align: center;
 }
 
-
 .codebook-modal {
   max-width: none;
-  opacity: 0.95
+  opacity: 0.95;
+}
+
+.modal-open {
+  .navigation-scoda {
+    z-index: 1;
+  }
+  .hero-block-title {
+    z-index: 1;
+  }
+  .tooglebtn {
+    z-index: 1;
+  }
 }
 
 .filter-container-row {

--- a/scoda/static/src/sass/components/_hero_collapsible.scss
+++ b/scoda/static/src/sass/components/_hero_collapsible.scss
@@ -94,12 +94,12 @@ body {
     font-weight: bold;
     letter-spacing: 0;
     line-height: 32px;
-    z-index: 1;
+    z-index: 100000;
 
   }
 
   .tooglebtn {
-    z-index: 1;
+    z-index: 100000;
   }
   .hero-block-vspacer {
     height:5%;

--- a/scoda/static/src/sass/components/_navigation-scoda.scss
+++ b/scoda/static/src/sass/components/_navigation-scoda.scss
@@ -1,7 +1,7 @@
 .navigation-scoda {
     position: fixed;
     width: 100%;
-    z-index: 1;
+    z-index: 1000000000;
     background-color: white;
 
 


### PR DESCRIPTION
I added a css class that would override the z-index of the navigation bar + page title to prevent it from displaying on top of the filter modal.